### PR TITLE
reuse namespace, no need for a "Test" namespace.

### DIFF
--- a/tests/PhpUnitsOfMeasure/PhysicalQuantityTest.php
+++ b/tests/PhpUnitsOfMeasure/PhysicalQuantityTest.php
@@ -1,9 +1,6 @@
 <?php
 
-namespace PhpUnitsOfMeasureTest;
-
-use PhpUnitsOfMeasure\PhysicalQuantity;
-use PhpUnitsOfMeasure\UnitOfMeasureInterface;
+namespace PhpUnitsOfMeasure;
 
 class PhysicalQuantityTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/PhpUnitsOfMeasure/UnitOfMeasureTest.php
+++ b/tests/PhpUnitsOfMeasure/UnitOfMeasureTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpUnitsOfMeasureTest;
+namespace PhpUnitsOfMeasure;
 
 use PhpUnitsOfMeasure\UnitOfMeasure;
 

--- a/tests/phpunit_bootstrap.php
+++ b/tests/phpunit_bootstrap.php
@@ -1,4 +1,4 @@
 <?php
 
-$loader = require __DIR__ . '/../vendor/autoload.php';
-$loader->add('PhpUnitsOfMeasureTest', __DIR__);
+$loader = require(__DIR__ . '/../vendor/autoload.php');
+$loader->add('PhpUnitsOfMeasure\\', __DIR__);


### PR DESCRIPTION
A "Test" namespace is not needed. Test classes can reside in the same namespace as the source classes. 
