### PR TITLE
Travis : prevent API limit lockup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - php: 5.5
 
 before_script:
-    - composer install --verbose --dev --prefer-dist -o
+    - composer install --verbose --dev --prefer-source --no-interaction -o
 
 script:
     - ./vendor/bin/phpunit -c ./tests


### PR DESCRIPTION
Prevent the issue of build failed by API limited
ex. 
https://travis-ci.org/triplepoint/php-units-of-measure/jobs/6968782

ref.
https://github.com/laravel/framework/pull/1229/files
