### PR TITLE
Add support for metres, and litres (not a typo)

### DIFF
--- a/source/PhpUnitsOfMeasure/PhysicalQuantity/Acceleration.php
+++ b/source/PhpUnitsOfMeasure/PhysicalQuantity/Acceleration.php
@@ -28,7 +28,9 @@ class Acceleration extends PhysicalQuantity
             array(
                 'm/s²',
                 'meter per second squared',
-                'meters per second squared'
+                'meters per second squared',
+                'metre per second squared',
+                'metres per second squared'
             )
         );
         $this->registerUnitOfMeasure($newUnit);

--- a/source/PhpUnitsOfMeasure/PhysicalQuantity/Area.php
+++ b/source/PhpUnitsOfMeasure/PhysicalQuantity/Area.php
@@ -28,7 +28,9 @@ class Area extends PhysicalQuantity
             array(
                 'm²',
                 'meter squared',
-                'meters squared'
+                'meters squared',
+                'metre squared',
+                'metres squared'
             )
         );
         $this->registerUnitOfMeasure($newUnit);
@@ -45,7 +47,9 @@ class Area extends PhysicalQuantity
             array(
                 'mm²',
                 'millimeter squared',
-                'millimeters squared'
+                'millimeters squared',
+                'millimetre squared',
+                'millimetres squared'
             )
         );
         $this->registerUnitOfMeasure($newUnit);
@@ -62,7 +66,9 @@ class Area extends PhysicalQuantity
             array(
                 'cm²',
                 'centimeter squared',
-                'centimeters squared'
+                'centimeters squared',
+                'centimetre squared',
+                'centimetres squared'
             )
         );
         $this->registerUnitOfMeasure($newUnit);
@@ -79,7 +85,9 @@ class Area extends PhysicalQuantity
             array(
                 'dm²',
                 'decimeter squared',
-                'decimeters squared'
+                'decimeters squared',
+                'decimetre squared',
+                'decimetres squared'
             )
         );
         $this->registerUnitOfMeasure($newUnit);
@@ -96,7 +104,9 @@ class Area extends PhysicalQuantity
             array(
                 'km²',
                 'kilometer squared',
-                'kilometers squared'
+                'kilometers squared',
+                'kilometre squared',
+                'kilometres squared'
             )
         );
         $this->registerUnitOfMeasure($newUnit);
@@ -150,9 +160,6 @@ class Area extends PhysicalQuantity
                 'miles squared'
             )
         );
-        $newUnit->addAlias('mi²');
-        $newUnit->addAlias('mile squared');
-        $newUnit->addAlias('miles squared');
         $this->registerUnitOfMeasure($newUnit);
 
         // Yard squared
@@ -170,9 +177,6 @@ class Area extends PhysicalQuantity
                 'yards squared'
             )
         );
-        $newUnit->addAlias('yd²');
-        $newUnit->addAlias('yard squared');
-        $newUnit->addAlias('yards squared');
         $this->registerUnitOfMeasure($newUnit);
 
 
@@ -189,7 +193,6 @@ class Area extends PhysicalQuantity
                 'hectares'
             )
         );
-
         $this->registerUnitOfMeasure($newUnit);
 
 
@@ -207,7 +210,6 @@ class Area extends PhysicalQuantity
                 'acres'
             )
         );
-
         $this->registerUnitOfMeasure($newUnit);
     }
 }

--- a/source/PhpUnitsOfMeasure/PhysicalQuantity/Length.php
+++ b/source/PhpUnitsOfMeasure/PhysicalQuantity/Length.php
@@ -24,10 +24,14 @@ class Length extends PhysicalQuantity
             },
             function ($x) {
                 return $x;
-            }
+            },
+            array(
+                'meter',
+                'meters',
+                'metre',
+                'metres'
+            )
         );
-        $newUnit->addAlias('meter');
-        $newUnit->addAlias('meters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Millimeter
@@ -38,10 +42,14 @@ class Length extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 0.001;
-            }
+            },
+            array(
+                'millimeter',
+                'millimeters',
+                'millimetre',
+                'millimetres'
+            )
         );
-        $newUnit->addAlias('millimeter');
-        $newUnit->addAlias('millimeters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Centimeter
@@ -52,10 +60,14 @@ class Length extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 0.01;
-            }
+            },
+            array(
+                'centimeter',
+                'centimeters',
+                'centimetre',
+                'centimetres'
+            )
         );
-        $newUnit->addAlias('centimeter');
-        $newUnit->addAlias('centimeters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Decimeter
@@ -66,10 +78,14 @@ class Length extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 0.1;
-            }
+            },
+            array(
+                'decimeter',
+                'decimeters',
+                'decimetre',
+                'decimetres'
+            )
         );
-        $newUnit->addAlias('decimeter');
-        $newUnit->addAlias('decimeters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Kilometer
@@ -80,10 +96,14 @@ class Length extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 1000;
-            }
+            },
+            array(
+                'kilometer',
+                'kilometers',
+                'kilometre',
+                'kilometres'
+            )
         );
-        $newUnit->addAlias('kilometer');
-        $newUnit->addAlias('kilometers');
         $this->registerUnitOfMeasure($newUnit);
 
         // Foot
@@ -94,10 +114,12 @@ class Length extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 0.3048;
-            }
+            },
+            array(
+                'foot',
+                'feet'
+            )
         );
-        $newUnit->addAlias('foot');
-        $newUnit->addAlias('feet');
         $this->registerUnitOfMeasure($newUnit);
 
         // Inch

--- a/source/PhpUnitsOfMeasure/PhysicalQuantity/Pressure.php
+++ b/source/PhpUnitsOfMeasure/PhysicalQuantity/Pressure.php
@@ -77,10 +77,13 @@ class Pressure extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 133.3224;
-            }
+            },
+            array(
+                'milimeters of mercury',
+                'milimetres of mercury',
+                'torr'
+            )
         );
-        $newUnit->addAlias('milimeters of mercury');
-        $newUnit->addAlias('torr');
         $this->registerUnitOfMeasure($newUnit);
 
         // Pound per Square Inch

--- a/source/PhpUnitsOfMeasure/PhysicalQuantity/Velocity.php
+++ b/source/PhpUnitsOfMeasure/PhysicalQuantity/Velocity.php
@@ -24,10 +24,14 @@ class Velocity extends PhysicalQuantity
             },
             function ($x) {
                 return $x;
-            }
+            },
+            array(
+                'meters per second',
+                'meter per second',
+                'metres per second',
+                'metre per second',
+            )
         );
-        $newUnit->addAlias('meters per second');
-        $newUnit->addAlias('meter per second');
         $this->registerUnitOfMeasure($newUnit);
     }
 }

--- a/source/PhpUnitsOfMeasure/PhysicalQuantity/Volume.php
+++ b/source/PhpUnitsOfMeasure/PhysicalQuantity/Volume.php
@@ -24,11 +24,15 @@ class Volume extends PhysicalQuantity
             },
             function ($x) {
                 return $x;
-            }
+            },
+            array(
+                'm³',
+                'cubic meter',
+                'cubic meters',
+                'cubic metre',
+                'cubic metres'
+            )
         );
-        $newUnit->addAlias('m³');
-        $newUnit->addAlias('cubic meter');
-        $newUnit->addAlias('cubic meters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Cubic millimeter
@@ -39,11 +43,16 @@ class Volume extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 1e-9;
-            }
+            },
+            array(
+                'mm³',
+                'cubic millimeter',
+                'cubic millimeters',
+                'cubic millimetre',
+                'cubic millimetres'
+            )
         );
-        $newUnit->addAlias('mm³');
-        $newUnit->addAlias('cubic millimeter');
-        $newUnit->addAlias('cubic millimeters');
+
         $this->registerUnitOfMeasure($newUnit);
 
         // Cubic centimeter
@@ -54,11 +63,15 @@ class Volume extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 1e-6;
-            }
+            },
+            array(
+                'cm³',
+                'cubic centimeter',
+                'cubic centimeters',
+                'cubic centimetre',
+                'cubic centimetres'
+            )
         );
-        $newUnit->addAlias('cm³');
-        $newUnit->addAlias('cubic centimeter');
-        $newUnit->addAlias('cubic centimeters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Cubic decimeter
@@ -69,11 +82,15 @@ class Volume extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 1e-3;
-            }
+            },
+            array(
+                'dm³',
+                'cubic decimeter',
+                'cubic decimeters',
+                'cubic decimetre',
+                'cubic decimetres'
+            )
         );
-        $newUnit->addAlias('dm³');
-        $newUnit->addAlias('cubic decimeter');
-        $newUnit->addAlias('cubic decimeters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Cubic kilometer
@@ -84,11 +101,16 @@ class Volume extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 1e9;
-            }
+            },
+            array(
+                'km³',
+                'cubic kilometer',
+                'cubic kilometers',
+                'cubic kilometre',
+                'cubic kilometres'
+            )
         );
-        $newUnit->addAlias('km³');
-        $newUnit->addAlias('cubic kilometer');
-        $newUnit->addAlias('cubic kilometers');
+
         $this->registerUnitOfMeasure($newUnit);
 
         // Cubic foot
@@ -144,10 +166,14 @@ class Volume extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 1e-6;
-            }
+            },
+            array(
+                'milliliter',
+                'milliliters',
+                'millilitre',
+                'millilitres'
+            )
         );
-        $newUnit->addAlias('milliliter');
-        $newUnit->addAlias('milliliters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Centiliters
@@ -158,10 +184,14 @@ class Volume extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 1e-5;
-            }
+            },
+            array(
+                'centiliter',
+                'centiliters',
+                'centilitre',
+                'centilitres'
+            )
         );
-        $newUnit->addAlias('centiliter');
-        $newUnit->addAlias('centiliters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Deciliter
@@ -172,10 +202,14 @@ class Volume extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 1e-4;
-            }
+            },
+            array(
+                'deciliter',
+                'deciliters',
+                'decilitre',
+                'decilitres'
+            )
         );
-        $newUnit->addAlias('deciliter');
-        $newUnit->addAlias('deciliters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Liter
@@ -186,10 +220,14 @@ class Volume extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 1e-3;
-            }
+            },
+            array(
+                'liter',
+                'liters',
+                'litre',
+                'litres',
+            )
         );
-        $newUnit->addAlias('liter');
-        $newUnit->addAlias('liters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Decaliter
@@ -200,10 +238,14 @@ class Volume extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 1e-2;
-            }
+            },
+            array(
+                'decaliter',
+                'decaliters',
+                'decalitre',
+                'decalitres'
+            )
         );
-        $newUnit->addAlias('decaliter');
-        $newUnit->addAlias('decaliters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Hectoliter
@@ -214,10 +256,14 @@ class Volume extends PhysicalQuantity
             },
             function ($x) {
                 return $x * 1e-1;
-            }
+            },
+            array(
+                'hectoliter',
+                'hectoliters',
+                'hectolitre',
+                'hectolitres'
+            )
         );
-        $newUnit->addAlias('hectoliter');
-        $newUnit->addAlias('hectoliters');
         $this->registerUnitOfMeasure($newUnit);
 
         // Cup


### PR DESCRIPTION
Hey Jonathan,

This PR is simply to add the international versions of meter, and liter. Metre, and litre respectfully.

I also removed duplicate inserts of aliases on miles squared, and yards squared.

Kind Regards,
Paul Croker.
