### PR TITLE
Added us liquid measurements and tests

### DIFF
--- a/source/PhysicalQuantity/Volume.php
+++ b/source/PhysicalQuantity/Volume.php
@@ -132,8 +132,35 @@ class Volume extends PhysicalQuantity
 
         // Cup
         $newUnit = UnitOfMeasure::linearUnitFactory('cup', 2.365882e-4);
-        $newUnit->addAlias('cup');
         $newUnit->addAlias('cups');
+        $this->registerUnitOfMeasure($newUnit);
+
+        // Gallon
+        $newUnit = UnitOfMeasure::linearUnitFactory('gallon', 3.7854118e-3);
+        $newUnit->addAlias('gallons');
+        $newUnit->addAlias('us gal');
+        $this->registerUnitOfMeasure($newUnit);
+
+        // Quart
+        $newUnit = UnitOfMeasure::linearUnitFactory('quart', 9.4635295e-4);
+        $newUnit->addAlias('quarts');
+        $newUnit->addAlias('qt');
+        $newUnit->addAlias('qts');
+        $newUnit->addAlias('liq qt');
+        $this->registerUnitOfMeasure($newUnit);
+
+        // Fluid Ounce
+        $newUnit = UnitOfMeasure::linearUnitFactory('fluid ounce', 2.957353e-5);
+        $newUnit->addAlias('fluid ounces');
+        $newUnit->addAlias('fluid-ounce');
+        $newUnit->addAlias('fl oz');
+        $this->registerUnitOfMeasure($newUnit);
+
+        // Pint
+        $newUnit = UnitOfMeasure::linearUnitFactory('pint', 4.73176475e-4);
+        $newUnit->addAlias('pints');
+        $newUnit->addAlias('pt');
+        $newUnit->addAlias('liq pt');
         $this->registerUnitOfMeasure($newUnit);
     }
 }

--- a/tests/PhysicalQuantity/VolumeTest.php
+++ b/tests/PhysicalQuantity/VolumeTest.php
@@ -80,12 +80,39 @@ class VolumeTest extends AbstractPhysicalQuantityTestCase
         'hectolitre',
         'hectolitres',
         'cup',
-        'cup',
         'cups',
+        'gallon',
+        'gallons',
+        'us gal',
+        'quart',
+        'quarts',
+        'qt',
+        'qts',
+        'liq qt',
+        'fluid ounce',
+        'fluid ounces',
+        'fluid-ounce',
+        'fl oz',
+        'pint',
+        'pints',
+        'pt',
+        'liq pt',
     ];
 
     protected function instantiateTestQuantity()
     {
         return new Volume(1, 'm^3');
+    }
+
+    public function test4QuartsInGallon()
+    {
+        $volume = new Volume(4, 'quarts');
+        $this->assertEquals(1, $volume->toUnit('gallon'));
+    }
+
+    public function test8PintsInGallon()
+    {
+        $volume = new Volume(8, 'pints');
+        $this->assertEquals(1, $volume->toUnit('gallon'));
     }
 }


### PR DESCRIPTION
Needed us liquid measurements so I added them in.

I noticed there is a disparity between other libraries and the published NIST coefficiants

For instance:
http://physics.nist.gov/Pubs/SP811/appenB9.html
http://en.wikipedia.org/wiki/Quart#United_States_liquid_quart
https://github.com/gentooboontoo/js-quantities/blob/master/src/quantities.js#L113

All have varying levels of precision. 

I matched liquids up to the more precise values in js-quantities so that I could match our front-end. Perhaps this is not what you want.
