### PR TITLE
PhysicalQuantity interface change

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vagrant"]
-	path = vagrant
-	url = https://github.com/triplepoint/quick-vagrant.git

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a PHP library for representing and converting physical units of measure.
 use PhpUnitsOfMeasure\PhysicalQuantity\Length;
 
 $height = new Length(6.16, 'feet');
-echo $height->toUnit('m');
+echo $height->toUnit('m')->getValue();
 
 // would print 1.87757, which is 6.16 feet in meters.
 ```
@@ -35,7 +35,7 @@ use PhpUnitsOfMeasure\PhysicalQuantity\Length;
 // Free to operate on lengths in any unit of measure
 function isTooTallToRideThisTrain( Length $height )
 {
-  return $height->toUnit('ft') > 5;
+  return $height->toUnit('ft')->getValue() > 5;
 }
 
 // Calling the function now allows any unit to be used:
@@ -64,7 +64,7 @@ As in the examples above, the basic usage of this library is in representing phy
 use PhpUnitsOfMeasure\PhysicalQuantity\Mass;
 
 $quantity = new Mass(6, 'lbs');
-echo $quantity->toUnit('g');
+echo $quantity->toUnit('g')->getValue();
 ```
 It's also possible to implicity cast a quantity to a string, which will display its original value:
 
@@ -139,7 +139,7 @@ Length::addUnit($cubit);
 
 // Now that the unit is registered, you can cast the measurement to any other
 // measure of length
-echo $length->toUnit('feet'); // '21'
+echo $length->toUnit('feet'); // '21 feet'
 ```
 
 ##### Shorthand Factory Methods
@@ -162,7 +162,7 @@ Length::addUnit($meter);
 ```
 
 ##### Automatically Generating Metric Units
-For units that use the metric system, there's a convenience trait available for classes which implement`PhysicalQuantityInterface` which will automatically generate the full continuum of metric units from a single unit.  For instance:
+For units that use the metric system, there's a convenience trait available for classes which implement`PhysicalQuantity` which will automatically generate the full continuum of metric units from a single unit.  For instance:
 
 ``` php
 namespace PhpUnitsOfMeasure\PhysicalQuantity;
@@ -256,7 +256,7 @@ use PhpUnitsOfMeasure\PhysicalQuantity\Length;
 $length = new Length(4, 'footses');
 
 // Fetch the unit of measure object that represents the 'ft' unit
-$footUnit = Length::getUnit('ft');
+$footUnit = Length::getUnitByNameOrAlias('ft');
 
 // Any alias names for this unit can be added here, to make it easier
 // to use variations
@@ -264,7 +264,7 @@ $footUnit->addAlias('footses');
 
 // Now that the unit has been modified with its new alias, you can cast
 // the measurement to any other measure of length
-echo $length->toUnit('m'); // '1.2192'
+echo $length->toUnit('m'); // '1.2192 m'
 ```
 
 And of course, if you need to add the alias permanently, you can do so in the initialize() method of the quantity's class, as shown above.
@@ -287,7 +287,7 @@ In this way, no feature-development work is ever directly contributed to `master
 End users of this repository should only use tagged commits in production.  Users interested in the current 'soon-to-be-released' code may use `develop`, with the understanding that it changes quickly.  All other existing branches (if any) should be considered 'feature' branches in development, and not yet ready for use.
 
 ### Local Testing Environment
-There's a Vagrant virtual machine configuration included which is suitable for running the necessary unit tests.  To bring up the machine, make sure you have Vagrant and Virtualbox installed, and from the project root directory:
+~~There's a Vagrant virtual machine configuration included which is suitable for running the necessary unit tests.  To bring up the machine, make sure you have Vagrant and Virtualbox installed, and from the project root directory:~~
 
 
 ``` bash

--- a/source/AbstractPhysicalQuantity.php
+++ b/source/AbstractPhysicalQuantity.php
@@ -162,7 +162,7 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantity
     /**
      * Returns a new PhysicalQuantity in the given unit of measure
      *
-     * @internal param UnitOfMeasureInterface|string $toUnit The desired unit of measure, or a string name of one
+     * @param UnitOfMeasureInterface|string $toUnit The desired unit of measure, or a string name of one
      * @return PhysicalQuantity
      * @throws Exception\UnknownUnitOfMeasure
      */

--- a/source/AbstractPhysicalQuantity.php
+++ b/source/AbstractPhysicalQuantity.php
@@ -130,11 +130,39 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantityInterface
     }
 
     /**
+     * @return float
+     */
+    public function getOriginalValue()
+    {
+        return $this->originalValue;
+    }
+
+    /**
+     * @return UnitOfMeasure
+     */
+    public function getOriginalUnit()
+    {
+        return static::getUnit($this->originalUnit);
+    }
+
+    /**
+     * @return UnitOfMeasure
+     */
+    public function getNativeUnit()
+    {
+        return static::getUnit($this->originalUnit);
+    }
+
+    /**
      * @see \PhpUnitsOfMeasure\PhysicalQuantityInterface::toUnit
      */
     public function toUnit($toUnit)
     {
-        return $this->toUnitOfMeasure(static::getUnit($toUnit));
+        if (is_string($toUnit)) {
+            $toUnit = static::getUnit($toUnit);
+        }
+
+        return $this->toUnitOfMeasure($toUnit);
     }
 
     /**
@@ -146,7 +174,7 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantityInterface
      */
     private function toUnitOfMeasure(UnitOfMeasureInterface $unit)
     {
-        $thisValueInNativeUnit = $this->toNativeUnit();
+        $thisValueInNativeUnit = $this->toNativeUnit()->getOriginalValue();
         return $unit->convertValueFromNativeUnitOfMeasure($thisValueInNativeUnit);
     }
 
@@ -155,8 +183,11 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantityInterface
      */
     public function toNativeUnit()
     {
-        return static::getUnit($this->originalUnit)
-            ->convertValueToNativeUnitOfMeasure($this->originalValue);
+        return new static(
+            static::getUnit($this->originalUnit)
+                  ->convertValueToNativeUnitOfMeasure($this->originalValue),
+            static::getUnit($this->originalUnit)->getName()
+        );
     }
 
     /**
@@ -179,7 +210,7 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantityInterface
             ]);
         }
 
-        $quantityValueInThisOriginalUnit = $quantity->toUnitOfMeasure(static::getUnit($this->originalUnit));
+        $quantityValueInThisOriginalUnit = $quantity->toUnit(static::getUnit($this->originalUnit));
         $newValue = $this->originalValue + $quantityValueInThisOriginalUnit;
 
         return new static($newValue, static::getUnit($this->originalUnit)->getName());
@@ -197,7 +228,7 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantityInterface
             ]);
         }
 
-        $quantityValueInThisOriginalUnit = $quantity->toUnitOfMeasure(static::getUnit($this->originalUnit));
+        $quantityValueInThisOriginalUnit = $quantity->toUnit(static::getUnit($this->originalUnit));
         $newValue = $this->originalValue - $quantityValueInThisOriginalUnit;
 
         return new static($newValue, static::getUnit($this->originalUnit)->getName());

--- a/source/AbstractPhysicalQuantity.php
+++ b/source/AbstractPhysicalQuantity.php
@@ -165,6 +165,16 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantity
     }
 
     /**
+     * Returns the original unit of measure string this quantity was initialized
+     *
+     * @return string
+     */
+    public function getOriginalUnit()
+    {
+        return $this->originalUnit;
+    }
+
+    /**
      * Returns the unit of measure this PhysicalQuantity was initialized
      *
      * @return UnitOfMeasure
@@ -264,7 +274,19 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantity
     }
 
     /**
+     * @param PhysicalQuantity $quantity
+     * @return bool
+     */
+    public function equals(PhysicalQuantity $quantity)
+    {
+        return $this->toNativeUnit()->getValue() === $quantity->toNativeUnit()->getValue();
+    }
+
+
+    /**
      * @see \PhpUnitsOfMeasure\PhysicalQuantityInterface::isEquivalentQuantity
+     * @param PhysicalQuantity $testQuantity
+     * @return bool
      */
     public function isEquivalentQuantity(PhysicalQuantity $testQuantity)
     {

--- a/source/AbstractPhysicalQuantity.php
+++ b/source/AbstractPhysicalQuantity.php
@@ -57,6 +57,31 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantity
     }
 
     /**
+     * Get the native unit of measure
+     *
+     * @throws Exception\UndefinedNativeUnitOfMeasure
+     *
+     * @return UnitOfMeasureInterface
+     */
+    public static function getNativeUnit()
+    {
+        // If this class hasn't been initialized yet, do so now
+        if (!is_array(static::$unitDefinitions)) {
+            static::$unitDefinitions = [];
+            static::initialize();
+        }
+
+        foreach (static::$unitDefinitions as $unitOfMeasure) {
+            if ($unitOfMeasure->isNativeUnit()) {
+                return $unitOfMeasure;
+            }
+        }
+
+        throw new Exception\UndefinedNativeUnitOfMeasure([':qty' => get_called_class()]);
+    }
+
+
+    /**
      * Given a unit of measure, determine if its name or any of its aliases conflict
      * with the set of already-known unit names and aliases.
      *
@@ -149,15 +174,6 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantity
         return static::getUnitByNameOrAlias($this->originalUnit);
     }
 
-    /**
-     * Returns a new PhysicalQuantity in the quantity's native unit of measure
-     *
-     * @return PhysicalQuantity
-     */
-    public function getNativeUnit()
-    {
-        return static::getUnitByNameOrAlias($this->originalUnit);
-    }
 
     /**
      * Returns a new PhysicalQuantity in the given unit of measure
@@ -199,7 +215,7 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantity
         return new static(
             static::getUnitByNameOrAlias($this->originalUnit)
                   ->convertValueToNativeUnitOfMeasure($this->originalValue),
-            static::getUnitByNameOrAlias($this->originalUnit)->getName()
+            static::getNativeUnit()->getName()
         );
     }
 

--- a/source/Exception/UndefinedNativeUnitOfMeasure.php
+++ b/source/Exception/UndefinedNativeUnitOfMeasure.php
@@ -1,0 +1,7 @@
+<?php
+namespace PhpUnitsOfMeasure\Exception;
+
+class UndefinedNativeUnitOfMeasure extends AbstractPhysicalQuantityException
+{
+    protected $error = 'Undefined native unit of measure for physical quantity :qty.';
+}

--- a/source/NativeUnitOfMeasure.php
+++ b/source/NativeUnitOfMeasure.php
@@ -1,0 +1,25 @@
+<?php
+namespace PhpUnitsOfMeasure;
+
+class NativeUnitOfMeasure extends UnitOfMeasure
+{
+    /**
+     * Configure this object's mandatory properties.
+     *
+     * @param string   $name           This unit of measure's canonical name
+     *
+     * @throws Exception\NonStringUnitName
+     */
+    public function __construct($name)
+    {
+        parent::__construct(
+            $name,
+            function ($valueInNativeUnit) {
+                return $valueInNativeUnit;
+            },
+            function ($valueInThisUnit) {
+                return $valueInThisUnit;
+            }
+        );
+    }
+}

--- a/source/PhysicalQuantity.php
+++ b/source/PhysicalQuantity.php
@@ -4,40 +4,39 @@ namespace PhpUnitsOfMeasure;
 /**
  * classes which implement this interface represent individual physical quantities.
  */
-interface PhysicalQuantityInterface
+interface PhysicalQuantity
 {
     /**
-     * Returns the original scalar value
+     * Returns the scalar value this PhysicalQuantity was initialized
      *
      * @return float
      */
-    public function getOriginalValue();
+    public function getValue();
 
     /**
-     * Returns the original unit of measure
+     * Returns the unit of measure this PhysicalQuantity was initialized
      *
      * @return UnitOfMeasure
      */
-    public function getOriginalUnit();
+    public function getUnit();
 
     /**
-     * Fetch the measurement, in the given unit of measure
+     * Returns a new PhysicalQuantity in the given unit of measure
      *
      * @param  UnitOfMeasureInterface|string $unit The desired unit of measure, or a string name of one
-     *
-     * @return float The measurement cast in the requested units
+     * @return PhysicalQuantity
      */
     public function toUnit($unit);
 
     /**
-     * Fetch the measurement in the quantity's native unit of measure
+     * Returns a new PhysicalQuantity in the quantity's native unit of measure
      *
-     * @return PhysicalQuantityInterface the measurement cast to the native unit of measurement
+     * @return PhysicalQuantity
      */
     public function toNativeUnit();
 
     /**
-     * Display the value as a string, in the original unit of measure
+     * Display the value as a string, in the unit of measure this quantity was initialized with
      *
      * @return string The pretty-print version of the value, in the original unit of measure
      */
@@ -50,13 +49,13 @@ interface PhysicalQuantityInterface
      *
      * Also note that the two quantities must represent the same physical quantity.
      *
-     * @param PhysicalQuantityInterface $quantity The quantity to add to this one
+     * @param PhysicalQuantity $quantity The quantity to add to this one
      *
      * @throws \PhpUnitsOfMeasure\Exception\PhysicalQuantityMismatch when there is a mismatch between physical quantities
      *
-     * @return PhysicalQuantityInterface the new quantity
+     * @return PhysicalQuantity the new quantity
      */
-    public function add(PhysicalQuantityInterface $quantity);
+    public function add(PhysicalQuantity $quantity);
 
     /**
      * Subtract a given quantity from this quantity, and return a new quantity object.
@@ -65,13 +64,13 @@ interface PhysicalQuantityInterface
      *
      * Also note that the two quantities must represent the same physical quantity.
      *
-     * @param PhysicalQuantityInterface $quantity The quantity to subtract from this one
+     * @param PhysicalQuantity $quantity The quantity to subtract from this one
      *
      * @throws \PhpUnitsOfMeasure\Exception\PhysicalQuantityMismatch when there is a mismatch between physical quantities
      *
-     * @return PhysicalQuantityInterface the new quantity
+     * @return PhysicalQuantity the new quantity
      */
-    public function subtract(PhysicalQuantityInterface $quantity);
+    public function subtract(PhysicalQuantity $quantity);
 
     /**
      * Determine whether the given PhysicalQuantityInterface object represents the same
@@ -80,9 +79,9 @@ interface PhysicalQuantityInterface
      *
      * Note that this is not considering magnitude, and is only comparing dimensions.
      *
-     * @param PhysicalQuantityInterface $testQuantity
+     * @param PhysicalQuantity $testQuantity
      *
      * @return boolean True if the quantities are the same, false if not.
      */
-    public function isEquivalentQuantity(PhysicalQuantityInterface $testQuantity);
+    public function isEquivalentQuantity(PhysicalQuantity $testQuantity);
 }

--- a/source/PhysicalQuantity.php
+++ b/source/PhysicalQuantity.php
@@ -73,6 +73,14 @@ interface PhysicalQuantity
     public function subtract(PhysicalQuantity $quantity);
 
     /**
+     * Compares this quantity with the given quantity
+     *
+     * @param PhysicalQuantity $quantity
+     * @return bool
+     */
+    public function equals(PhysicalQuantity $quantity);
+
+    /**
      * Determine whether the given PhysicalQuantityInterface object represents the same
      * physical quantity as this object.  This is used, for example, to determine if
      * two quantities can be added to or subtracted from each other.

--- a/source/PhysicalQuantityInterface.php
+++ b/source/PhysicalQuantityInterface.php
@@ -7,6 +7,20 @@ namespace PhpUnitsOfMeasure;
 interface PhysicalQuantityInterface
 {
     /**
+     * Returns the original scalar value
+     *
+     * @return float
+     */
+    public function getOriginalValue();
+
+    /**
+     * Returns the original unit of measure
+     *
+     * @return UnitOfMeasure
+     */
+    public function getOriginalUnit();
+
+    /**
      * Fetch the measurement, in the given unit of measure
      *
      * @param  UnitOfMeasureInterface|string $unit The desired unit of measure, or a string name of one
@@ -18,7 +32,7 @@ interface PhysicalQuantityInterface
     /**
      * Fetch the measurement in the quantity's native unit of measure
      *
-     * @return float the measurement cast to the native unit of measurement
+     * @return PhysicalQuantityInterface the measurement cast to the native unit of measurement
      */
     public function toNativeUnit();
 

--- a/source/UnitOfMeasure.php
+++ b/source/UnitOfMeasure.php
@@ -48,7 +48,7 @@ class UnitOfMeasure implements UnitOfMeasureInterface
      */
     public static function nativeUnitFactory($name)
     {
-        return static::linearUnitFactory($name, 1);
+        return new NativeUnitOfMeasure($name);
     }
 
     /**
@@ -152,6 +152,10 @@ class UnitOfMeasure implements UnitOfMeasureInterface
             throw new Exception\NonNumericValue([':value' => $value]);
         }
 
+        if ($this->isNativeUnit()) {
+            return $value;
+        }
+
         $callable = $this->fromNativeUnit;
         return $callable($value);
     }
@@ -163,6 +167,10 @@ class UnitOfMeasure implements UnitOfMeasureInterface
     {
         if (!is_numeric($value)) {
             throw new Exception\NonNumericValue([':value' => $value]);
+        }
+
+        if ($this->isNativeUnit()) {
+            return $value;
         }
 
         $callable = $this->toNativeUnit;
@@ -177,5 +185,15 @@ class UnitOfMeasure implements UnitOfMeasureInterface
     public function __toString()
     {
         return $this->name;
+    }
+
+    /**
+     * Returns true if this UnitOfMeasure is the native unit
+     *
+     * @return bool
+     */
+    public function isNativeUnit()
+    {
+        return $this instanceof NativeUnitOfMeasure;
     }
 }

--- a/source/UnitOfMeasure.php
+++ b/source/UnitOfMeasure.php
@@ -168,4 +168,14 @@ class UnitOfMeasure implements UnitOfMeasureInterface
         $callable = $this->toNativeUnit;
         return $callable($value);
     }
+
+    /**
+     * Display the unit as a string, in the native unit of measure
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->name;
+    }
 }

--- a/source/UnitOfMeasureInterface.php
+++ b/source/UnitOfMeasureInterface.php
@@ -85,4 +85,11 @@ interface UnitOfMeasureInterface
      * @return float the new value in this unit of measure
      */
     public function convertValueToNativeUnitOfMeasure($value);
+
+    /**
+     * Display the unit as a string, in the native unit of measure
+     *
+     * @return string
+     */
+    public function __toString();
 }

--- a/source/UnitOfMeasureInterface.php
+++ b/source/UnitOfMeasureInterface.php
@@ -86,6 +86,15 @@ interface UnitOfMeasureInterface
      */
     public function convertValueToNativeUnitOfMeasure($value);
 
+
+    /**
+     * Returns true if this UnitOfMeasure is the native unit
+     *
+     * @return bool
+     */
+    public function isNativeUnit();
+
+
     /**
      * Display the unit as a string, in the native unit of measure
      *

--- a/tests/AbstractPhysicalQuantityTest.php
+++ b/tests/AbstractPhysicalQuantityTest.php
@@ -101,6 +101,19 @@ class AbstractPhysicalQuantityTest extends PHPUnit_Framework_TestCase
         $value = new Wonkicity(1.234, 42);
     }
 
+    public function testGetOriginalValue()
+    {
+        $value = new Wonkicity(1.234, 'u');
+        $this->assertEquals(1.234, $value->getOriginalValue());
+    }
+
+    public function testGetOriginalUnit()
+    {
+        $value = new Wonkicity(1.234, 'u');
+        $this->assertEquals('u', $value->getOriginalUnit()->getName());
+    }
+
+
     /**
      * @dataProvider quantityConversionsProvider
      * @covers \PhpUnitsOfMeasure\AbstractPhysicalQuantity::toUnit

--- a/tests/AbstractPhysicalQuantityTest.php
+++ b/tests/AbstractPhysicalQuantityTest.php
@@ -10,6 +10,7 @@ use PhpUnitsOfMeasure\Exception\DuplicateUnitNameOrAlias;
 use PhpUnitsOfMeasure\Exception\NonNumericValue;
 use PhpUnitsOfMeasure\Exception\NonStringUnitName;
 use PhpUnitsOfMeasure\Exception\UnknownUnitOfMeasure;
+use PhpUnitsOfMeasureTest\Fixtures\PhysicalQuantity\InvalidQuantity;
 use PhpUnitsOfMeasureTest\Fixtures\PhysicalQuantity\Wonkicity;
 use PhpUnitsOfMeasureTest\Fixtures\PhysicalQuantity\Woogosity;
 
@@ -129,7 +130,7 @@ class AbstractPhysicalQuantityTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider quantityConversionsProvider
-     * @covers \PhpUnitsOfMeasure\AbstractPhysicalQuantity::toNativeUnit
+     * @covers \PhpUnitsOfMeasure\AbstractPhysicalQuantity::toUnit
      */
     public function testUnitConvertsToArbitraryUnit(
         AbstractPhysicalQuantity $value,
@@ -137,6 +138,21 @@ class AbstractPhysicalQuantityTest extends PHPUnit_Framework_TestCase
         $valueInArbitraryUnit
     ) {
         $this->assertSame($valueInArbitraryUnit, $value->toUnit($arbitraryUnit)->getValue());
+    }
+
+    /**
+     * @dataProvider nativeUnitProvider
+     * @covers \PhpUnitsOfMeasure\AbstractPhysicalQuantity::toNativeUnit
+     */
+    public function testToNativeUnit(
+        $shouldThrowException,
+        AbstractPhysicalQuantity $value,
+        $nativeUnit
+    ) {
+        if ($shouldThrowException) {
+            $this->setExpectedException('PhpUnitsOfMeasure\Exception\UndefinedNativeUnitOfMeasure');
+        }
+        $this->assertSame($nativeUnit, $value->toNativeUnit()->getUnit()->getName());
     }
 
     /**
@@ -247,6 +263,25 @@ class AbstractPhysicalQuantityTest extends PHPUnit_Framework_TestCase
             [new Wonkicity(2, 'vorps'), 'vorps', 2.0],
             [new Woogosity(2, 'p'), 'lupees', 2*4.5],
             [new Woogosity(2, 'p'), 'millilupees', 2*4.5*1000],
+        ];
+    }
+
+    /**
+     * Provide native unit testing data
+     * 1) the object from which to start
+     * 2) The expected native unit
+     */
+    public function nativeUnitProvider()
+    {
+        return [
+            [false, new Wonkicity(2, 'u'), 'u'],
+            [false, new Wonkicity(2, 'uvee'), 'u'],
+            [false, new Wonkicity(2, 'vorp'), 'u'],
+            [false, new Wonkicity(2, 'vorps'), 'u'],
+            [false, new Woogosity(2, 'lupee'), 'l'],
+            [false, new Woogosity(2, 'p'), 'l'],
+            [false, new Woogosity(2, 'plurp'), 'l'],
+            [true, new InvalidQuantity(2, 'x'), 'x']
         ];
     }
 

--- a/tests/AbstractPhysicalQuantityTest.php
+++ b/tests/AbstractPhysicalQuantityTest.php
@@ -57,22 +57,22 @@ class AbstractPhysicalQuantityTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \PhpUnitsOfMeasure\AbstractPhysicalQuantity::getUnit
+     * @covers \PhpUnitsOfMeasure\AbstractPhysicalQuantity::getUnitByNameOrAlias
      */
     public function testGetUnit()
     {
-        $unit = Wonkicity::getUnit('u');
+        $unit = Wonkicity::getUnitByNameOrAlias('u');
 
         $this->assertSame('u', $unit->getName());
     }
 
     /**
-     * @covers \PhpUnitsOfMeasure\AbstractPhysicalQuantity::getUnit
+     * @covers \PhpUnitsOfMeasure\AbstractPhysicalQuantity::getUnitByNameOrAlias
      * @expectedException \PhpUnitsOfMeasure\Exception\UnknownUnitOfMeasure
      */
     public function testGetUnitFailsOnUnknownUnit()
     {
-        Wonkicity::getUnit('someUnknownUnit');
+        Wonkicity::getUnitByNameOrAlias('someUnknownUnit');
     }
 
     /**
@@ -104,13 +104,13 @@ class AbstractPhysicalQuantityTest extends PHPUnit_Framework_TestCase
     public function testGetOriginalValue()
     {
         $value = new Wonkicity(1.234, 'u');
-        $this->assertEquals(1.234, $value->getOriginalValue());
+        $this->assertEquals(1.234, $value->getValue());
     }
 
     public function testGetOriginalUnit()
     {
         $value = new Wonkicity(1.234, 'u');
-        $this->assertEquals('u', $value->getOriginalUnit()->getName());
+        $this->assertEquals('u', $value->getUnit()->getName());
     }
 
 
@@ -136,7 +136,7 @@ class AbstractPhysicalQuantityTest extends PHPUnit_Framework_TestCase
         $arbitraryUnit,
         $valueInArbitraryUnit
     ) {
-        $this->assertSame($valueInArbitraryUnit, $value->toUnit($arbitraryUnit));
+        $this->assertSame($valueInArbitraryUnit, $value->toUnit($arbitraryUnit)->getValue());
     }
 
     /**
@@ -170,7 +170,7 @@ class AbstractPhysicalQuantityTest extends PHPUnit_Framework_TestCase
     ) {
         $unserializedValue = unserialize(serialize($value));
 
-        $this->assertSame($valueInArbitraryUnit, $unserializedValue->toUnit($arbitraryUnit));
+        $this->assertSame($valueInArbitraryUnit, $unserializedValue->toUnit($arbitraryUnit)->getValue());
     }
 
     /**

--- a/tests/Fixtures/PhysicalQuantity/InvalidQuantity.php
+++ b/tests/Fixtures/PhysicalQuantity/InvalidQuantity.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhpUnitsOfMeasureTest\Fixtures\PhysicalQuantity;
+
+use PhpUnitsOfMeasure\AbstractPhysicalQuantity;
+use PhpUnitsOfMeasure\UnitOfMeasure;
+
+class InvalidQuantity extends AbstractPhysicalQuantity
+{
+    protected static $unitDefinitions;
+
+    protected static function initialize()
+    {
+        $unit = UnitOfMeasure::linearUnitFactory('x', 4.5);
+        $unit->addAlias('foo');
+        static::addUnit($unit);
+    }
+}

--- a/tests/PhysicalQuantity/AngleTest.php
+++ b/tests/PhysicalQuantity/AngleTest.php
@@ -257,12 +257,12 @@ class AngleTest extends AbstractPhysicalQuantityTestCase
     public function testToDegrees()
     {
         $angle = new Angle(2 * M_PI, 'rad');
-        $this->assertEquals(360, $angle->toUnit('deg'));
+        $this->assertEquals(360, $angle->toUnit('deg')->getValue());
     }
 
     public function testToRadians()
     {
         $angle = new Angle(720, 'degree');
-        $this->assertEquals(M_PI * 4, $angle->toUnit('rad'));
+        $this->assertEquals(M_PI * 4, $angle->toUnit('rad')->getValue());
     }
 }

--- a/tests/PhysicalQuantity/AreaTest.php
+++ b/tests/PhysicalQuantity/AreaTest.php
@@ -70,7 +70,7 @@ class AreaTest extends AbstractPhysicalQuantityTestCase
     {
         $area = new Area(3, 'ha');
 
-        $this->assertEquals(30000, $area->toUnit("m^2"));
+        $this->assertEquals(30000, $area->toUnit("m^2")->getValue());
     }
 
     /**
@@ -81,7 +81,7 @@ class AreaTest extends AbstractPhysicalQuantityTestCase
     {
         $area = new Area(13, 'ac');
 
-        $area = round($area->toUnit("m^2"), 6);
+        $area = round($area->toUnit("m^2")->getValue(), 6);
 
         $this->assertEquals(52609.133491, $area);
     }
@@ -89,12 +89,12 @@ class AreaTest extends AbstractPhysicalQuantityTestCase
     public function testToAre()
     {
         $area = new Area(100, 'm^2');
-        $this->assertEquals(1, $area->toUnit('are'));
+        $this->assertEquals(1, $area->toUnit('are')->getValue());
     }
 
     public function testToDecare()
     {
         $area = new Area(1000, 'm^2');
-        $this->assertEquals(1, $area->toUnit('decare'));
+        $this->assertEquals(1, $area->toUnit('decare')->getValue());
     }
 }

--- a/tests/PhysicalQuantity/EnergyTest.php
+++ b/tests/PhysicalQuantity/EnergyTest.php
@@ -66,24 +66,24 @@ class EnergyTest extends AbstractPhysicalQuantityTestCase
     public function testToKilowattHour()
     {
         $quantity = new Energy(1000, 'Wh');
-        $this->assertEquals(1, $quantity->toUnit('kWh'));
+        $this->assertEquals(1, $quantity->toUnit('kWh')->getValue());
     }
 
     public function testToWattHour()
     {
         $quantity = new Energy(1, 'kWh');
-        $this->assertEquals(1000, $quantity->toUnit('Wh'));
+        $this->assertEquals(1000, $quantity->toUnit('Wh')->getValue());
     }
 
     public function testToMegaJoule()
     {
         $quantity = new Energy(1, 'kWh');
-        $this->assertEquals(3.6, $quantity->toUnit('megajoule'));
+        $this->assertEquals(3.6, $quantity->toUnit('megajoule')->getValue());
     }
 
     public function testToJoule()
     {
         $quantity = new Energy(1, 'Wh');
-        $this->assertEquals(3600, $quantity->toUnit('joule'));
+        $this->assertEquals(3600, $quantity->toUnit('joule')->getValue());
     }
 }

--- a/tests/PhysicalQuantity/LengthTest.php
+++ b/tests/PhysicalQuantity/LengthTest.php
@@ -143,36 +143,36 @@ class LengthTest extends AbstractPhysicalQuantityTestCase
     public function testToMillimeters()
     {
         $quantity = new Length(5, 'm');
-        $this->assertEquals(5000, $quantity->toUnit('mm'));
+        $this->assertEquals(5000, $quantity->toUnit('mm')->getValue());
     }
 
     public function testToMegameters()
     {
         $quantity = new Length(5, 'm');
-        $this->assertEquals(5/1e6, $quantity->toUnit('Mm'));
+        $this->assertEquals(5/1e6, $quantity->toUnit('Mm')->getValue());
     }
 
     public function testToInches()
     {
         $quantity = new Length(2, 'ft');
-        $this->assertEquals(24, $quantity->toUnit('in'));
+        $this->assertEquals(24, $quantity->toUnit('in')->getValue());
     }
 
     public function testToNauticalMiles()
     {
         $quantity = new Length(3704, 'm');
-        $this->assertEquals(2, $quantity->toUnit('nmi'));
+        $this->assertEquals(2, $quantity->toUnit('nmi')->getValue());
     }
 
     public function testToScandinavianMil()
     {
         $quantity = new Length(20000, 'm');
-        $this->assertEquals(2, $quantity->toUnit('mil'));
+        $this->assertEquals(2, $quantity->toUnit('mil')->getValue());
     }
 
     public function testToAstronomicalUnit()
     {
         $quantity = new Length(150000000, 'km');
-        $this->assertEquals(1.0026880683402668, $quantity->toUnit('AU'));
+        $this->assertEquals(1.0026880683402668, $quantity->toUnit('AU')->getValue());
     }
 }

--- a/tests/PhysicalQuantity/MassTest.php
+++ b/tests/PhysicalQuantity/MassTest.php
@@ -95,24 +95,24 @@ class MassTest extends AbstractPhysicalQuantityTestCase
     public function testToGrams()
     {
         $quantity = new Mass(5, 'kg');
-        $this->assertEquals(5000, $quantity->toUnit('g'));
+        $this->assertEquals(5000, $quantity->toUnit('g')->getValue());
     }
 
     public function testToMilligrams()
     {
         $quantity = new Mass(5, 'kg');
-        $this->assertEquals(5*1e6, $quantity->toUnit('mg'));
+        $this->assertEquals(5*1e6, $quantity->toUnit('mg')->getValue());
     }
 
     public function testToPounds()
     {
         $quantity = new Mass(16, 'oz');
-        $this->assertEquals(1, $quantity->toUnit('pound'));
+        $this->assertEquals(1, $quantity->toUnit('pound')->getValue());
     }
 
     public function testToStones()
     {
         $quantity = new Mass(14, 'pound');
-        $this->assertEquals(1, $quantity->toUnit('st'));
+        $this->assertEquals(1, $quantity->toUnit('st')->getValue());
     }
 }

--- a/tests/PhysicalQuantity/TimeTest.php
+++ b/tests/PhysicalQuantity/TimeTest.php
@@ -148,42 +148,42 @@ class TimeTest extends AbstractPhysicalQuantityTestCase
     public function testToSeconds()
     {
         $angle = new Time(5, 'm');
-        $this->assertEquals(300, $angle->toUnit('seconds'));
+        $this->assertEquals(300, $angle->toUnit('seconds')->getValue());
     }
 
     public function testToMinutes()
     {
         $angle = new Time(360, 'sec');
-        $this->assertEquals(6, $angle->toUnit('min'));
+        $this->assertEquals(6, $angle->toUnit('min')->getValue());
     }
 
     public function testToHours()
     {
         $angle = new Time(120, 'mins');
-        $this->assertEquals(2, $angle->toUnit('hrs'));
+        $this->assertEquals(2, $angle->toUnit('hrs')->getValue());
     }
 
     public function testToDays()
     {
         $angle = new Time(72, 'hours');
-        $this->assertEquals(3, $angle->toUnit('days'));
+        $this->assertEquals(3, $angle->toUnit('days')->getValue());
     }
 
     public function testToWeeks()
     {
         $angle = new Time(14, 'd');
-        $this->assertEquals(2, $angle->toUnit('week'));
+        $this->assertEquals(2, $angle->toUnit('week')->getValue());
     }
 
     public function testToGregorianYears()
     {
         $angle = new Time(365.2425, 'd');
-        $this->assertEquals(1, $angle->toUnit('yr'));
+        $this->assertEquals(1, $angle->toUnit('yr')->getValue());
     }
 
     public function testToJulianYears()
     {
         $angle = new Time(365.25, 'd');
-        $this->assertEquals(1, $angle->toUnit('jyr'));
+        $this->assertEquals(1, $angle->toUnit('jyr')->getValue());
     }
 }

--- a/tests/PhysicalQuantity/VelocityTest.php
+++ b/tests/PhysicalQuantity/VelocityTest.php
@@ -37,24 +37,24 @@ class VelocityTest extends AbstractPhysicalQuantityTestCase
     public function testToKilometersPerHour()
     {
         $speed = new Velocity(1, 'km/h');
-        $this->assertEquals(0.277778, $speed->toUnit('m/s'));
+        $this->assertEquals(0.277778, $speed->toUnit('m/s')->getValue());
     }
 
     public function testToFeetPerSecond()
     {
         $speed = new Velocity(2, 'm/s');
-        $this->assertEquals(6.561679790026246, $speed->toUnit('ft/s'));
+        $this->assertEquals(6.561679790026246, $speed->toUnit('ft/s')->getValue());
     }
 
     public function testToKmPerHour()
     {
         $speed = new Velocity(2, 'mph');
-        $this->assertEquals(3.2186854250516594, $speed->toUnit('km/h'));
+        $this->assertEquals(3.2186854250516594, $speed->toUnit('km/h')->getValue());
     }
 
     public function testToKnot()
     {
         $speed = new Velocity(2, 'm/s');
-        $this->assertEquals(3.8876923435786983, $speed->toUnit('knot'));
+        $this->assertEquals(3.8876923435786983, $speed->toUnit('knot')->getValue());
     }
 }

--- a/tests/UnitOfMeasureTest.php
+++ b/tests/UnitOfMeasureTest.php
@@ -220,4 +220,23 @@ class UnitOfMeasureTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(11.234, $uom->convertValueToNativeUnitOfMeasure('string'));
     }
+
+    /**
+     * @covers \PhpUnitsOfMeasure\UnitOfMeasure::__toString
+     */
+    public function testToString()
+    {
+        $uom = new UnitOfMeasure(
+            'quatloos',
+            function ($valueInNativeUnit) {
+                return $valueInNativeUnit;
+            },
+            function ($valueInThisUnit) {
+                return $valueInThisUnit;
+            }
+        );
+
+        $this->assertSame('quatloos', (string) $uom);
+    }
+
 }

--- a/tests/UnitOfMeasureTest.php
+++ b/tests/UnitOfMeasureTest.php
@@ -238,5 +238,4 @@ class UnitOfMeasureTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('quatloos', (string) $uom);
     }
-
 }

--- a/tests/UnitOfMeasureTest.php
+++ b/tests/UnitOfMeasureTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpUnitsOfMeasureTest;
 
+use PhpUnitsOfMeasure\NativeUnitOfMeasure;
 use PhpUnitsOfMeasure\UnitOfMeasure;
 
 class UnitOfMeasureTest extends \PHPUnit_Framework_TestCase
@@ -237,5 +238,35 @@ class UnitOfMeasureTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame('quatloos', (string) $uom);
+    }
+
+    /**
+     * @covers \PhpUnitsOfMeasure\UnitOfMeasure::isNativeUnit
+     */
+    public function testIsNativeUnit()
+    {
+        $uom = new NativeUnitOfMeasure(
+            'quatloos'
+        );
+
+        $this->assertSame(true, $uom->isNativeUnit());
+    }
+
+    /**
+     * @covers \PhpUnitsOfMeasure\UnitOfMeasure::isNativeUnit
+     */
+    public function testIsNotNativeUnit()
+    {
+        $uom = new UnitOfMeasure(
+            'quatloos',
+            function ($valueInNativeUnit) {
+                return $valueInNativeUnit;
+            },
+            function ($valueInThisUnit) {
+                return $valueInThisUnit;
+            }
+        );
+
+        $this->assertSame(false, $uom->isNativeUnit());
     }
 }


### PR DESCRIPTION
Inspired from issue #35 (2.+ 3.) this PR proposes changes to the interface of PhysicalQuantity

The interface `PhysicalQuantityInterface` is renamed into `PhysicalQuantity`, which emphasizes more on being a type rather than being an interface (e.g. when being used in type hints).

Methods `PhysicalQuantity::toUnit()` and `PhysicalQuantity::toNativeUnit()` now return new PhysicalQuantity instances.

This PR also adds the missing scalar getter methods `getValue()` and `getUnit()`, which return the original value and the unit when the instance was created. Therefor the static method `AbstractPhysicalQuantity::getUnit()` has to be renamed to `getUnitByNameOrAlias`.

Finally, removes the non-existant submodule "vagrant" `https://github.com/triplepoint/quick-vagrant.git`.

