### PR TITLE
Added some aliases and units

### DIFF
--- a/source/PhysicalQuantity/Area.php
+++ b/source/PhysicalQuantity/Area.php
@@ -14,8 +14,8 @@ class Area extends AbstractPhysicalQuantity
         $metersquared = UnitOfMeasure::nativeUnitFactory('m^2');
         $metersquared->addAlias('m²');
         $metersquared->addAlias('meter squared');
-		$metersquared->addAlias('square meter');
-		$metersquared->addAlias('square meters');
+        $metersquared->addAlias('square meter');
+        $metersquared->addAlias('square meters');
         $metersquared->addAlias('meters squared');
         $metersquared->addAlias('metre squared');
         $metersquared->addAlias('metres squared');
@@ -25,8 +25,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit = UnitOfMeasure::linearUnitFactory('mm^2', 1e-6);
         $newUnit->addAlias('mm²');
         $newUnit->addAlias('millimeter squared');
-		$newUnit->addAlias('square millimeter');
-		$newUnit->addAlias('square millimeters');
+        $newUnit->addAlias('square millimeter');
+        $newUnit->addAlias('square millimeters');
         $newUnit->addAlias('millimeters squared');
         $newUnit->addAlias('millimetre squared');
         $newUnit->addAlias('millimetres squared');
@@ -36,8 +36,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit = UnitOfMeasure::linearUnitFactory('cm^2', 1e-4);
         $newUnit->addAlias('cm²');
         $newUnit->addAlias('centimeter squared');
-		$newUnit->addAlias('square centimeter');
-		$newUnit->addAlias('square centimeters');
+        $newUnit->addAlias('square centimeter');
+        $newUnit->addAlias('square centimeters');
         $newUnit->addAlias('centimeters squared');
         $newUnit->addAlias('centimetre squared');
         $newUnit->addAlias('centimetres squared');
@@ -47,8 +47,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit = UnitOfMeasure::linearUnitFactory('dm^2', 1e-2);
         $newUnit->addAlias('dm²');
         $newUnit->addAlias('decimeter squared');
-		$newUnit->addAlias('square decimeters');
-		$newUnit->addAlias('square decimeter');
+        $newUnit->addAlias('square decimeters');
+        $newUnit->addAlias('square decimeter');
         $newUnit->addAlias('decimeters squared');
         $newUnit->addAlias('decimetre squared');
         $newUnit->addAlias('decimetres squared');
@@ -59,8 +59,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit->addAlias('km²');
         $newUnit->addAlias('kilometer squared');
         $newUnit->addAlias('kilometers squared');
-		$newUnit->addAlias('square kilometer');
-		$newUnit->addAlias('square kilometers');
+        $newUnit->addAlias('square kilometer');
+        $newUnit->addAlias('square kilometers');
         $newUnit->addAlias('kilometre squared');
         $newUnit->addAlias('kilometres squared');
         static::addUnit($newUnit);
@@ -69,8 +69,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit = UnitOfMeasure::linearUnitFactory('ft^2', 9.290304e-2);
         $newUnit->addAlias('ft²');
         $newUnit->addAlias('foot squared');
-		$newUnit->addAlias('square foot');
-		$newUnit->addAlias('square feet');
+        $newUnit->addAlias('square foot');
+        $newUnit->addAlias('square feet');
         $newUnit->addAlias('feet squared');
         static::addUnit($newUnit);
 
@@ -78,8 +78,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit = UnitOfMeasure::linearUnitFactory('in^2', 6.4516e-4);
         $newUnit->addAlias('in²');
         $newUnit->addAlias('inch squared');
-		$newUnit->addAlias('square inch');
-		$newUnit->addAlias('square inches');
+        $newUnit->addAlias('square inch');
+        $newUnit->addAlias('square inches');
         $newUnit->addAlias('inches squared');
         static::addUnit($newUnit);
 
@@ -88,8 +88,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit->addAlias('mi²');
         $newUnit->addAlias('mile squared');
         $newUnit->addAlias('miles squared');
-		$newUnit->addAlias('square mile');
-		$newUnit->addAlias('square miles');
+        $newUnit->addAlias('square mile');
+        $newUnit->addAlias('square miles');
         static::addUnit($newUnit);
 
         // Yard squared
@@ -97,8 +97,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit->addAlias('yd²');
         $newUnit->addAlias('yard squared');
         $newUnit->addAlias('yards squared');
-		$newUnit->addAlias('square yard');
-		$newUnit->addAlias('square yards');
+        $newUnit->addAlias('square yard');
+        $newUnit->addAlias('square yards');
         static::addUnit($newUnit);
 
         // Are

--- a/source/PhysicalQuantity/Area.php
+++ b/source/PhysicalQuantity/Area.php
@@ -14,6 +14,8 @@ class Area extends AbstractPhysicalQuantity
         $metersquared = UnitOfMeasure::nativeUnitFactory('m^2');
         $metersquared->addAlias('m²');
         $metersquared->addAlias('meter squared');
+		$metersquared->addAlias('square meter');
+		$metersquared->addAlias('square meters');
         $metersquared->addAlias('meters squared');
         $metersquared->addAlias('metre squared');
         $metersquared->addAlias('metres squared');
@@ -23,6 +25,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit = UnitOfMeasure::linearUnitFactory('mm^2', 1e-6);
         $newUnit->addAlias('mm²');
         $newUnit->addAlias('millimeter squared');
+		$newUnit->addAlias('square millimeter');
+		$newUnit->addAlias('square millimeters');
         $newUnit->addAlias('millimeters squared');
         $newUnit->addAlias('millimetre squared');
         $newUnit->addAlias('millimetres squared');
@@ -32,6 +36,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit = UnitOfMeasure::linearUnitFactory('cm^2', 1e-4);
         $newUnit->addAlias('cm²');
         $newUnit->addAlias('centimeter squared');
+		$newUnit->addAlias('square centimeter');
+		$newUnit->addAlias('square centimeters');
         $newUnit->addAlias('centimeters squared');
         $newUnit->addAlias('centimetre squared');
         $newUnit->addAlias('centimetres squared');
@@ -41,6 +47,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit = UnitOfMeasure::linearUnitFactory('dm^2', 1e-2);
         $newUnit->addAlias('dm²');
         $newUnit->addAlias('decimeter squared');
+		$newUnit->addAlias('square decimeters');
+		$newUnit->addAlias('square decimeter');
         $newUnit->addAlias('decimeters squared');
         $newUnit->addAlias('decimetre squared');
         $newUnit->addAlias('decimetres squared');
@@ -51,6 +59,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit->addAlias('km²');
         $newUnit->addAlias('kilometer squared');
         $newUnit->addAlias('kilometers squared');
+		$newUnit->addAlias('square kilometer');
+		$newUnit->addAlias('square kilometers');
         $newUnit->addAlias('kilometre squared');
         $newUnit->addAlias('kilometres squared');
         static::addUnit($newUnit);
@@ -59,6 +69,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit = UnitOfMeasure::linearUnitFactory('ft^2', 9.290304e-2);
         $newUnit->addAlias('ft²');
         $newUnit->addAlias('foot squared');
+		$newUnit->addAlias('square foot');
+		$newUnit->addAlias('square feet');
         $newUnit->addAlias('feet squared');
         static::addUnit($newUnit);
 
@@ -66,6 +78,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit = UnitOfMeasure::linearUnitFactory('in^2', 6.4516e-4);
         $newUnit->addAlias('in²');
         $newUnit->addAlias('inch squared');
+		$newUnit->addAlias('square inch');
+		$newUnit->addAlias('square inches');
         $newUnit->addAlias('inches squared');
         static::addUnit($newUnit);
 
@@ -74,6 +88,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit->addAlias('mi²');
         $newUnit->addAlias('mile squared');
         $newUnit->addAlias('miles squared');
+		$newUnit->addAlias('square mile');
+		$newUnit->addAlias('square miles');
         static::addUnit($newUnit);
 
         // Yard squared
@@ -81,6 +97,8 @@ class Area extends AbstractPhysicalQuantity
         $newUnit->addAlias('yd²');
         $newUnit->addAlias('yard squared');
         $newUnit->addAlias('yards squared');
+		$newUnit->addAlias('square yard');
+		$newUnit->addAlias('square yards');
         static::addUnit($newUnit);
 
         // Are

--- a/source/PhysicalQuantity/Temperature.php
+++ b/source/PhysicalQuantity/Temperature.php
@@ -54,10 +54,8 @@ class Temperature extends AbstractPhysicalQuantity
                 return ($x + 459.67) * 5/9;
             }
         );
-        $newUnit->addAlias('F');
         $newUnit->addAlias('f');
         $newUnit->addAlias('fahrenheit');
-		$newUnit->addAlias('Fahrenheit');
         static::addUnit($newUnit);
 
         // Degree Rankine

--- a/source/PhysicalQuantity/Temperature.php
+++ b/source/PhysicalQuantity/Temperature.php
@@ -39,7 +39,9 @@ class Temperature extends AbstractPhysicalQuantity
             }
         );
         $newUnit->addAlias('C');
+        $newUnit->addAlias('c');
         $newUnit->addAlias('celsius');
+		$newUnit->addAlias('Celsius');
         static::addUnit($newUnit);
 
         // Degree Fahrenheit
@@ -53,7 +55,9 @@ class Temperature extends AbstractPhysicalQuantity
             }
         );
         $newUnit->addAlias('F');
+        $newUnit->addAlias('f');
         $newUnit->addAlias('fahrenheit');
+		$newUnit->addAlias('Fahrenheit');
         static::addUnit($newUnit);
 
         // Degree Rankine

--- a/source/PhysicalQuantity/Temperature.php
+++ b/source/PhysicalQuantity/Temperature.php
@@ -39,9 +39,7 @@ class Temperature extends AbstractPhysicalQuantity
             }
         );
         $newUnit->addAlias('C');
-        $newUnit->addAlias('c');
         $newUnit->addAlias('celsius');
-		$newUnit->addAlias('Celsius');
         static::addUnit($newUnit);
 
         // Degree Fahrenheit
@@ -54,7 +52,7 @@ class Temperature extends AbstractPhysicalQuantity
                 return ($x + 459.67) * 5/9;
             }
         );
-        $newUnit->addAlias('f');
+        $newUnit->addAlias('F');
         $newUnit->addAlias('fahrenheit');
         static::addUnit($newUnit);
 

--- a/source/PhysicalQuantity/Time.php
+++ b/source/PhysicalQuantity/Time.php
@@ -71,20 +71,20 @@ class Time extends AbstractPhysicalQuantity
         $newUnit->addAlias('gregorian years');
         static::addUnit($newUnit);
 
-		// Decade
-		$newUnit = UnitOfMeasure::linearUnitFactory('decade', 315569520);
-		$newUnit->addAlias('decades');
-		static::addUnit($newUnit);
+        // Decade
+        $newUnit = UnitOfMeasure::linearUnitFactory('decade', 315569520);
+        $newUnit->addAlias('decades');
+        static::addUnit($newUnit);
 
-		// Century
-		$newUnit = UnitOfMeasure::linearUnitFactory('century', 3155695200);
-		$newUnit->addAlias('centuries');
-		static::addUnit($newUnit);
+        // Century
+        $newUnit = UnitOfMeasure::linearUnitFactory('century', 3155695200);
+        $newUnit->addAlias('centuries');
+        static::addUnit($newUnit);
 
-		// Millennium
-		$newUnit = UnitOfMeasure::linearUnitFactory('millennium', 31556952000);
-		$newUnit->addAlias('millennia');
-		static::addUnit($newUnit);
+        // Millennium
+        $newUnit = UnitOfMeasure::linearUnitFactory('millennium', 31556952000);
+        $newUnit->addAlias('millennia');
+        static::addUnit($newUnit);
 
         // Julian year, understood as 365.25 days
         $newUnit = UnitOfMeasure::linearUnitFactory('jyr', 31557600);

--- a/source/PhysicalQuantity/Time.php
+++ b/source/PhysicalQuantity/Time.php
@@ -72,23 +72,18 @@ class Time extends AbstractPhysicalQuantity
         static::addUnit($newUnit);
 
 		// Decade
-		$newUnit = UnitOfMeasure::linearUnitFactory('dc', 315569520);
-		$newUnit->addAlias('decade');
+		$newUnit = UnitOfMeasure::linearUnitFactory('decade', 315569520);
 		$newUnit->addAlias('decades');
 		static::addUnit($newUnit);
 
 		// Century
-		$newUnit = UnitOfMeasure::linearUnitFactory('cnt', 3155695200);
-		$newUnit->addAlias('century');
+		$newUnit = UnitOfMeasure::linearUnitFactory('century', 3155695200);
 		$newUnit->addAlias('centuries');
 		static::addUnit($newUnit);
 
 		// Millennium
-		$newUnit = UnitOfMeasure::linearUnitFactory('mln', 31556952000);
-		$newUnit->addAlias('millennium');
-		$newUnit->addAlias('millenniums');
-		$newUnit->addAlias('milleniums');
-		$newUnit->addAlias('millenium');
+		$newUnit = UnitOfMeasure::linearUnitFactory('millennium', 31556952000);
+		$newUnit->addAlias('millennia');
 		static::addUnit($newUnit);
 
         // Julian year, understood as 365.25 days

--- a/source/PhysicalQuantity/Time.php
+++ b/source/PhysicalQuantity/Time.php
@@ -71,6 +71,26 @@ class Time extends AbstractPhysicalQuantity
         $newUnit->addAlias('gregorian years');
         static::addUnit($newUnit);
 
+		// Decade
+		$newUnit = UnitOfMeasure::linearUnitFactory('dc', 315569520);
+		$newUnit->addAlias('decade');
+		$newUnit->addAlias('decades');
+		static::addUnit($newUnit);
+
+		// Century
+		$newUnit = UnitOfMeasure::linearUnitFactory('cnt', 3155695200);
+		$newUnit->addAlias('century');
+		$newUnit->addAlias('centuries');
+		static::addUnit($newUnit);
+
+		// Millennium
+		$newUnit = UnitOfMeasure::linearUnitFactory('mln', 31556952000);
+		$newUnit->addAlias('millennium');
+		$newUnit->addAlias('millenniums');
+		$newUnit->addAlias('milleniums');
+		$newUnit->addAlias('millenium');
+		static::addUnit($newUnit);
+
         // Julian year, understood as 365.25 days
         $newUnit = UnitOfMeasure::linearUnitFactory('jyr', 31557600);
         $newUnit->addAlias('julian year');

--- a/source/PhysicalQuantity/Volume.php
+++ b/source/PhysicalQuantity/Volume.php
@@ -137,34 +137,35 @@ class Volume extends AbstractPhysicalQuantity
 		static::addUnit($newUnit);
 
 		// tablespoon
-		$newUnit = UnitOfMeasure::linearUnitFactory('tbs', 0.00001478676);
+		$newUnit = UnitOfMeasure::linearUnitFactory('tbsp', 0.00001478676);
 		$newUnit->addAlias('tablespoon');
 		$newUnit->addAlias('tablespoons');
 		static::addUnit($newUnit);
 
 		// Gallon
-		$newUnit = UnitOfMeasure::linearUnitFactory('gallon', 3.7854118e-3);
+		$newUnit = UnitOfMeasure::linearUnitFactory('gal', 3.7854118e-3);
+		$newUnit->addAlias('gallon');
 		$newUnit->addAlias('gallons');
 		$newUnit->addAlias('us gal');
 		static::addUnit($newUnit);
 		// Quart
-		$newUnit = UnitOfMeasure::linearUnitFactory('quart', 9.4635295e-4);
+		$newUnit = UnitOfMeasure::linearUnitFactory('qt', 9.4635295e-4);
+		$newUnit->addAlias('quart');
 		$newUnit->addAlias('quarts');
-		$newUnit->addAlias('qt');
 		$newUnit->addAlias('qts');
 		$newUnit->addAlias('liq qt');
 		static::addUnit($newUnit);
 		// Fluid Ounce
-		$newUnit = UnitOfMeasure::linearUnitFactory('fluid ounce', 2.957353e-5);
-		$newUnit->addAlias('fluid ounces');
+		$newUnit = UnitOfMeasure::linearUnitFactory('oz', 2.957353e-5);
+		$newUnit->addAlias('fluid ounce');
+		$newUnit->addAlias('fluid-ounces');
 		$newUnit->addAlias('fluid oz');
-		$newUnit->addAlias('fluid-ounce');
 		$newUnit->addAlias('fl oz');
 		static::addUnit($newUnit);
 		// Pint
-		$newUnit = UnitOfMeasure::linearUnitFactory('pint', 4.73176475e-4);
+		$newUnit = UnitOfMeasure::linearUnitFactory('pt', 4.73176475e-4);
+		$newUnit->addAlias('pint');
 		$newUnit->addAlias('pints');
-		$newUnit->addAlias('pt');
 		$newUnit->addAlias('liq pt');
 		static::addUnit($newUnit);
     }

--- a/source/PhysicalQuantity/Volume.php
+++ b/source/PhysicalQuantity/Volume.php
@@ -130,43 +130,43 @@ class Volume extends AbstractPhysicalQuantity
         $newUnit->addAlias('cups');
         static::addUnit($newUnit);
 
-		// teaspoon
-		$newUnit = UnitOfMeasure::linearUnitFactory('tsp', 0.00000492892);
-		$newUnit->addAlias('teaspoon');
-		$newUnit->addAlias('teaspoons');
-		static::addUnit($newUnit);
+        // teaspoon
+        $newUnit = UnitOfMeasure::linearUnitFactory('tsp', 0.00000492892);
+        $newUnit->addAlias('teaspoon');
+        $newUnit->addAlias('teaspoons');
+        static::addUnit($newUnit);
 
-		// tablespoon
-		$newUnit = UnitOfMeasure::linearUnitFactory('tbsp', 0.00001478676);
-		$newUnit->addAlias('tablespoon');
-		$newUnit->addAlias('tablespoons');
-		static::addUnit($newUnit);
+        // tablespoon
+        $newUnit = UnitOfMeasure::linearUnitFactory('tbsp', 0.00001478676);
+        $newUnit->addAlias('tablespoon');
+        $newUnit->addAlias('tablespoons');
+        static::addUnit($newUnit);
 
-		// Gallon
-		$newUnit = UnitOfMeasure::linearUnitFactory('gal', 3.7854118e-3);
-		$newUnit->addAlias('gallon');
-		$newUnit->addAlias('gallons');
-		$newUnit->addAlias('us gal');
-		static::addUnit($newUnit);
-		// Quart
-		$newUnit = UnitOfMeasure::linearUnitFactory('qt', 9.4635295e-4);
-		$newUnit->addAlias('quart');
-		$newUnit->addAlias('quarts');
-		$newUnit->addAlias('qts');
-		$newUnit->addAlias('liq qt');
-		static::addUnit($newUnit);
-		// Fluid Ounce
-		$newUnit = UnitOfMeasure::linearUnitFactory('oz', 2.957353e-5);
-		$newUnit->addAlias('fluid ounce');
-		$newUnit->addAlias('fluid-ounces');
-		$newUnit->addAlias('fluid oz');
-		$newUnit->addAlias('fl oz');
-		static::addUnit($newUnit);
-		// Pint
-		$newUnit = UnitOfMeasure::linearUnitFactory('pt', 4.73176475e-4);
-		$newUnit->addAlias('pint');
-		$newUnit->addAlias('pints');
-		$newUnit->addAlias('liq pt');
-		static::addUnit($newUnit);
+        // Gallon
+        $newUnit = UnitOfMeasure::linearUnitFactory('gal', 3.7854118e-3);
+        $newUnit->addAlias('gallon');
+        $newUnit->addAlias('gallons');
+        $newUnit->addAlias('us gal');
+        static::addUnit($newUnit);
+        // Quart
+        $newUnit = UnitOfMeasure::linearUnitFactory('qt', 9.4635295e-4);
+        $newUnit->addAlias('quart');
+        $newUnit->addAlias('quarts');
+        $newUnit->addAlias('qts');
+        $newUnit->addAlias('liq qt');
+        static::addUnit($newUnit);
+        // Fluid Ounce
+        $newUnit = UnitOfMeasure::linearUnitFactory('oz', 2.957353e-5);
+        $newUnit->addAlias('fluid ounce');
+        $newUnit->addAlias('fluid-ounces');
+        $newUnit->addAlias('fluid oz');
+        $newUnit->addAlias('fl oz');
+        static::addUnit($newUnit);
+        // Pint
+        $newUnit = UnitOfMeasure::linearUnitFactory('pt', 4.73176475e-4);
+        $newUnit->addAlias('pint');
+        $newUnit->addAlias('pints');
+        $newUnit->addAlias('liq pt');
+        static::addUnit($newUnit);
     }
 }

--- a/source/PhysicalQuantity/Volume.php
+++ b/source/PhysicalQuantity/Volume.php
@@ -129,5 +129,43 @@ class Volume extends AbstractPhysicalQuantity
         $newUnit->addAlias('cup');
         $newUnit->addAlias('cups');
         static::addUnit($newUnit);
+
+		// teaspoon
+		$newUnit = UnitOfMeasure::linearUnitFactory('tsp', 0.00000492892);
+		$newUnit->addAlias('teaspoon');
+		$newUnit->addAlias('teaspoons');
+		static::addUnit($newUnit);
+
+		// tablespoon
+		$newUnit = UnitOfMeasure::linearUnitFactory('tbs', 0.00001478676);
+		$newUnit->addAlias('tablespoon');
+		$newUnit->addAlias('tablespoons');
+		static::addUnit($newUnit);
+
+		// Gallon
+		$newUnit = UnitOfMeasure::linearUnitFactory('gallon', 3.7854118e-3);
+		$newUnit->addAlias('gallons');
+		$newUnit->addAlias('us gal');
+		static::addUnit($newUnit);
+		// Quart
+		$newUnit = UnitOfMeasure::linearUnitFactory('quart', 9.4635295e-4);
+		$newUnit->addAlias('quarts');
+		$newUnit->addAlias('qt');
+		$newUnit->addAlias('qts');
+		$newUnit->addAlias('liq qt');
+		static::addUnit($newUnit);
+		// Fluid Ounce
+		$newUnit = UnitOfMeasure::linearUnitFactory('fluid ounce', 2.957353e-5);
+		$newUnit->addAlias('fluid ounces');
+		$newUnit->addAlias('fluid oz');
+		$newUnit->addAlias('fluid-ounce');
+		$newUnit->addAlias('fl oz');
+		static::addUnit($newUnit);
+		// Pint
+		$newUnit = UnitOfMeasure::linearUnitFactory('pint', 4.73176475e-4);
+		$newUnit->addAlias('pints');
+		$newUnit->addAlias('pt');
+		$newUnit->addAlias('liq pt');
+		static::addUnit($newUnit);
     }
 }

--- a/source/PhysicalQuantity/Volume.php
+++ b/source/PhysicalQuantity/Volume.php
@@ -156,11 +156,12 @@ class Volume extends AbstractPhysicalQuantity
         $newUnit->addAlias('liq qt');
         static::addUnit($newUnit);
         // Fluid Ounce
-        $newUnit = UnitOfMeasure::linearUnitFactory('oz', 2.957353e-5);
+        $newUnit = UnitOfMeasure::linearUnitFactory('fl oz', 2.957353e-5);
         $newUnit->addAlias('fluid ounce');
         $newUnit->addAlias('fluid-ounces');
         $newUnit->addAlias('fluid oz');
-        $newUnit->addAlias('fl oz');
+        $newUnit->addAlias('fl. oz.');
+        $newUnit->addAlias('oz. fl.');
         static::addUnit($newUnit);
         // Pint
         $newUnit = UnitOfMeasure::linearUnitFactory('pt', 4.73176475e-4);

--- a/source/PhysicalQuantity/Volume.php
+++ b/source/PhysicalQuantity/Volume.php
@@ -158,7 +158,7 @@ class Volume extends AbstractPhysicalQuantity
         // Fluid Ounce
         $newUnit = UnitOfMeasure::linearUnitFactory('fl oz', 2.957353e-5);
         $newUnit->addAlias('fluid ounce');
-        $newUnit->addAlias('fluid-ounces');
+        $newUnit->addAlias('fluid ounces');
         $newUnit->addAlias('fluid oz');
         $newUnit->addAlias('fl. oz.');
         $newUnit->addAlias('oz. fl.');


### PR DESCRIPTION
I used the correct abbreviations now for volumes, the times that I added do not have abbreviations because I couldn't find any official abbreviations.

I corrected the indenting also, I apologize for that, at my day job the company requires we use tabs instead of spaces, whereas your repository uses spaces (which is typically my preference, but my IDE is set to use tabs because of my job).

I will do the case insensitive conversion on a separate pull request in case you don't like my implementation.  It shouldn't prevent these new units from being added in.