### PR TITLE
Improved UOM mock in AbstractPhysicalQuantityTest

### DIFF
--- a/tests/AbstractPhysicalQuantityTest.php
+++ b/tests/AbstractPhysicalQuantityTest.php
@@ -30,6 +30,12 @@ class AbstractPhysicalQuantityTest extends PHPUnit_Framework_TestCase
             ->willReturn($name);
         $newUnit->method('getAliases')
             ->willReturn($aliases);
+        $newUnit->method('isAliasOf')
+            ->will($this->returnCallback(
+                function ($value) use ($aliases) {
+                    return in_array($value, $aliases);
+                }
+            ));
 
         return $newUnit;
     }


### PR DESCRIPTION
In order to address difficulties with pull request #64, this fix mocks out UnitOfMeasureInterface::isAliasOf() for the AbstractPhysicalQuantityTest unit test mock.