### PR TITLE
Add caching for unit lookups with getUnit()

### DIFF
--- a/source/AbstractPhysicalQuantity.php
+++ b/source/AbstractPhysicalQuantity.php
@@ -13,6 +13,23 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantityInterface
     // protected static $unitDefinitions;
 
     /**
+     * Static cache for unit lookups.
+     *
+     * @var UnitOfMeasureInterface[]
+     */
+    private static $unitCache = [];
+
+    /**
+     * Create a cache key for the unit lookup cache.
+     *
+     * @var UnitOfMeasureInterface[]
+     */
+    private static function buildUnitCacheKey($unit)
+    {
+        return get_called_class() . '#' . $unit;
+    }
+
+    /**
      * Register a new unit of measure for all instances of this this physical quantity.
      *
      * @throws Exception\DuplicateUnitNameOrAlias If the unit name or any alias already exists
@@ -47,9 +64,14 @@ abstract class AbstractPhysicalQuantity implements PhysicalQuantityInterface
             static::initialize();
         }
 
+        $key = static::buildUnitCacheKey($unit);
+        if (isset(self::$unitCache[$key])) {
+            return self::$unitCache[$key];
+        }
+
         foreach (static::$unitDefinitions as $unitOfMeasure) {
             if ($unit === $unitOfMeasure->getName() || $unitOfMeasure->isAliasOf($unit)) {
-                return $unitOfMeasure;
+                return self::$unitCache[$key] = $unitOfMeasure;
             }
         }
 


### PR DESCRIPTION
getUnit() in the worst case is an O(n) operation on the number of units and aliases. This patch adds a simple cache so that the cost is only incurred on the first call for a given unit or alias, which is a dramatic improvement for applications working with high numbers of values or conversions.

We are using the php-uom library in such an application that demands high performance and identified this as a bottleneck via Blackfire profiling. In the most intensive case getUnit() accounted for almost 50% of a ~500ms total runtime. This patch reduced its impact to near zero.

The cache was implemented as it is (as a static on AbstractPhysicalQuantity itself) so as not to break for consumers of the library with custom AbstractPhysicalQuantity subclasses (a static on the subclass would require modification of the subclass by the end user).