### PR TITLE
Use composer scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_script:
     - composer install --verbose --prefer-dist --no-interaction -o
 
 script:
-    - ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist ./tests
-    - ./vendor/bin/phpcs --encoding=utf-8 --extensions=php --standard=./tests/phpcs.xml -nsp ./
+    - composer test
+    - composer phpcs
 
 notifications:
     email: false

--- a/README.md
+++ b/README.md
@@ -307,14 +307,14 @@ composer.phar update --verbose --prefer-dist
 All the tests associated with this project can be manually run with:
 
 ``` bash
-vendor/bin/phpunit -c ./tests/phpunit.xml.dist ./tests
+composer test
 ```
 
 ### CodeSniffer
 Codesniffer verifies that coding standards are being met.  Once the project is built with development dependencies, you can run the checks with:
 
 ``` bash
-vendor/bin/phpcs --encoding=utf-8 --extensions=php --standard=./tests/phpcs.xml -nsp ./
+composer phpcs
 ```
 
 ### Continuous Integration

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
     "replace": {
         "triplepoint/php-units-of-measure": "*"
     },
+
+    "scripts": {
+        "test": "phpunit -c ./tests/phpunit.xml.dist ./tests",
+        "phpcs": "phpcs --encoding=utf-8 --extensions=php --standard=./tests/phpcs.xml -nsp ./"
+    },
     
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I noticed that you use full commands in Travis and in README. I think that using composer scripts is a better practice as you can reuse the script multiple times and it's easier to keep different places consistent. Replaced in Travis as well as the README. 